### PR TITLE
Fix docblock return type for replyTo

### DIFF
--- a/lib/classes/Swift/Mime/SimpleMessage.php
+++ b/lib/classes/Swift/Mime/SimpleMessage.php
@@ -274,7 +274,7 @@ class Swift_Mime_SimpleMessage extends Swift_Mime_MimePart
     /**
      * Get the reply-to address of this message.
      *
-     * @return string
+     * @return array
      */
     public function getReplyTo()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc update?   | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | n/a
| License       | MIT


When writing tests for my mailer class I got confused when checking the reply to field. `\Swift_Message->getReplyTo()` hinted me a string would be returned (presumably the email address) but this turned out to be a string.

Upon further inspection, the reply-to field is handled the same way as the sender- and to-fields so I've fixed the docblock to be in line with those and expected behavior.